### PR TITLE
完善屏蔽用户功能

### DIFF
--- a/lib/asset/black.dart
+++ b/lib/asset/black.dart
@@ -6,7 +6,7 @@ import 'package:offer_show/util/storage.dart';
 import 'package:provider/provider.dart';
 
 removeBlackWord(String t, BuildContext context) async {
-  //新增拉黑关键词
+  // 删除拉黑关键词
   String tmp = await getStorage(key: "black", initData: "[]");
   List tmp_arr = jsonDecode(tmp);
   if (tmp_arr.contains(t)) tmp_arr.remove(t);
@@ -17,7 +17,7 @@ removeBlackWord(String t, BuildContext context) async {
 }
 
 setBlackWord(String? t, BuildContext context) async {
-  //新增拉黑关键词
+  // 新增拉黑关键词
   String tmp = await getStorage(key: "black", initData: "[]");
   List tmp_arr = jsonDecode(tmp);
   if (!tmp_arr.contains(t)) tmp_arr.add(t);

--- a/lib/components/topic.dart
+++ b/lib/components/topic.dart
@@ -246,8 +246,8 @@ class _TopicState extends State<Topic> {
   _moreAction() async {
     showAction(
       context: context,
-      options: ["复制帖子链接", "举报反馈"],
-      icons: [Icons.copy, Icons.feedback_outlined],
+      options: ["复制帖子链接", "举报反馈", "屏蔽此人"],
+      icons: [Icons.copy, Icons.feedback_outlined, Icons.person_off_outlined],
       tap: (res) async {
         if (res == "屏蔽此贴") {
           await setBlackWord(widget.data!["title"], context);

--- a/lib/page/blacklist/black_list.dart
+++ b/lib/page/blacklist/black_list.dart
@@ -221,6 +221,7 @@ class _BlackListState extends State<BlackList> {
 
   _update() async {
     await setStorage(key: "black", value: jsonEncode(data));
+    data = data!.where((element) => element != null && element != "").toList();
     Provider.of<BlackProvider>(context, listen: false).black = data;
   }
 

--- a/lib/page/home/homeNew.dart
+++ b/lib/page/home/homeNew.dart
@@ -340,12 +340,12 @@ class _HomeNewState extends State<HomeNew> with AutomaticKeepAliveClientMixin {
           Provider.of<BlackProvider>(context, listen: false)
               .black!
               .forEach((element) {
-            if (i["title"].toString().contains(element) ||
-                i["subject"].toString().contains(element) ||
-                i["user_nick_name"].toString().contains(element)) {
-              flag = true;
-            }
-          });
+                if (i["title"].toString().contains(element) ||
+                    i["subject"].toString().contains(element) ||
+                    i["user_nick_name"].toString().contains(element)) {
+                  flag = true;
+                }
+              });
           return flag;
         }
 

--- a/lib/page/personal/personal.dart
+++ b/lib/page/personal/personal.dart
@@ -3,6 +3,7 @@ import 'package:dismissible_page/dismissible_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:offer_show/asset/bigScreen.dart';
+import 'package:offer_show/asset/black.dart';
 import 'package:offer_show/asset/color.dart';
 import 'package:offer_show/asset/home_desktop_mode.dart';
 import 'package:offer_show/asset/modal.dart';
@@ -228,9 +229,9 @@ class _PersonCenterState extends State<PersonCenter> {
   _tapMore() {
     showAction(
       context: context,
-      options: ["复制空间链接", "展示二维码"],
-      icons: [Icons.copy, Icons.qr_code],
-      tap: (res) {
+      options: ["复制空间链接", "展示二维码", "屏蔽此人"],
+      icons: [Icons.copy, Icons.qr_code, Icons.person_off_outlined],
+      tap: (res) async {
         if (res == "复制空间链接") {
           Navigator.pop(context);
           Clipboard.setData(
@@ -253,6 +254,13 @@ class _PersonCenterState extends State<PersonCenter> {
                   "https://bbs.uestc.edu.cn/home.php?mod=space&uid=${widget.param!["uid"]}",
             )
           ]);
+        }
+        if (res == "屏蔽此人") {
+          // print(res);
+          await setBlackWord(userInfo!["name"], context);
+          Navigator.pop(context);
+          showToast(context: context, type: XSToast.success, txt: "屏蔽成功");
+
         }
       },
     );

--- a/lib/page/topic/topic_comment.dart
+++ b/lib/page/topic/topic_comment.dart
@@ -438,6 +438,7 @@ class _CommentState extends State<Comment> {
         "复制文本内容",
         "举报反馈",
         _getBlack() ? "取消屏蔽此帖子" : "屏蔽此贴的ID",
+        "屏蔽此人",
         ...(is_my_comment ? ["追加内容"] : []),
         ...(is_me ? [widget.data["poststick"] == 1 ? "取消置顶评论" : "置顶评论"] : []),
         ...(is_my_comment ? ["删除评论"] : []),
@@ -446,6 +447,7 @@ class _CommentState extends State<Comment> {
         Icons.copy,
         Icons.feedback_outlined,
         _getBlack() ? Icons.remove_circle_outline_rounded : Icons.block,
+        Icons.person_off_outlined,
         ...(is_my_comment ? [Icons.edit] : []),
         ...(is_me
             ? [
@@ -469,6 +471,12 @@ class _CommentState extends State<Comment> {
         }
         if (res == "取消屏蔽此帖子" || res == "屏蔽此贴的ID") {
           _blackID();
+        }
+        if (res == "屏蔽此人") {
+          // print("屏蔽此人");
+          // print(widget.data["reply_name"]);
+          await setBlackWord(widget.data["reply_name"].toString(), context);
+          setState(() {});
         }
         if (res == "追加内容") {
           _append_cont();

--- a/lib/page/topic/topic_more.dart
+++ b/lib/page/topic/topic_more.dart
@@ -245,6 +245,7 @@ class _TopicDetailMoreState extends State<TopicDetailMore> {
         "复制帖子链接",
         "举报反馈",
         "屏蔽此贴",
+        "屏蔽楼主",
         ...(widget.data!["topic"]["user_id"] == await getUid() ? ["编辑帖子"] : []),
         ...(widget.data!["topic"]["user_id"] == await getUid() ? ["补充内容"] : []),
         ...(widget.data!["topic"]["user_id"] == await getUid() ? ["删除帖子"] : []),
@@ -255,6 +256,7 @@ class _TopicDetailMoreState extends State<TopicDetailMore> {
         Icons.content_copy_rounded,
         Icons.feedback_outlined,
         Icons.block,
+        Icons.person_off_outlined,
         ...(widget.data!["topic"]["user_id"] == await getUid()
             ? [Icons.edit]
             : []),
@@ -295,6 +297,12 @@ class _TopicDetailMoreState extends State<TopicDetailMore> {
         }
         if (res == "屏蔽此贴") {
           setBlackWord(widget.data!["topic"]["title"], context);
+          widget.block!();
+        }
+        if (res == "屏蔽楼主") {
+          // print("屏蔽楼主");
+          // print(widget.data!["topic"]["user_nick_name"]);
+          setBlackWord(widget.data!["topic"]["user_nick_name"], context);
           widget.block!();
         }
         if (res == "编辑帖子") {

--- a/lib/util/storage.dart
+++ b/lib/util/storage.dart
@@ -9,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 getStorage({required String key, String initData = ""}) async {
   SharedPreferences prefs = await SharedPreferences.getInstance();
+  // await prefs.clear(); // 本地数据出错时取消注释以便清除
   String? s = await prefs.getString(key);
   if (s == null) {
     await prefs.setString(key, initData);


### PR DESCRIPTION
1. 在更多的地方添加屏蔽用户操作：首页信息流（topic.dart）三个点、用户主页（personal.dart）三个点、回帖列表（topic_comment.dart）三个点、帖子详情（topic_more.dart）三个点。
2. 支持了屏蔽黑名单用户的回帖（topic_comment.dart）。
3. 其他代码风格变动：更新黑名单时去除 null 和空字符串（black_list.dart）、调整空格（homeNew.dart）、删除本地数据用于调试（storage.dart）（默认为注释状态）、typo（black.dart）。