### PR TITLE
修复使用 VPN 时上传附件的问题

### DIFF
--- a/lib/util/interface.dart
+++ b/lib/util/interface.dart
@@ -429,13 +429,17 @@ class Api {
     String myinfo_txt = await getStorage(key: "myinfo", initData: "");
     if (myinfo_txt != "") {
       Map<String, dynamic> myinfo = jsonDecode(myinfo_txt);
+      final isVpn = await isVPNEnabled();
       var request = http.MultipartRequest(
         'POST',
         Uri.parse(
-          base_url +
+          (isVpn ? vpn_base_url : base_url) +
               'mobcent/app/web/index.php?r=forum/sendattachmentex&type=image&module=forum&accessToken=${myinfo["token"]}&accessSecret=${myinfo["secret"]}',
         ),
       );
+      if (isVpn) {
+        request.headers['Cookie'] = await getVPNCookie();
+      }
       for (var i = 0; i < imgs!.length; i++) {
         String? tmp_jpg_path = imgs[i].path;
         if (imgs[i].path.split(".")[1] == "heic") {


### PR DESCRIPTION
上传附件的请求在 `lib/util/interface.dart` 中直接发起 HTTP 请求，未使用 `mid_request.dart` 中的方法，在 VPN 开启时未通过 VPN 代理，导致无法上传附件。